### PR TITLE
Updated dependency name

### DIFF
--- a/src/main/resources/webjars-requirejs.js
+++ b/src/main/resources/webjars-requirejs.js
@@ -1,4 +1,4 @@
 requirejs.config({
     paths: { "ui-sortable": webjars.path("ui-sortable", "sortable") },
-    shim: { "ui-sortable": [ "jqueryui" ] }
+    shim: { "ui-sortable": [ "jquery-ui" ] }
 });


### PR DESCRIPTION
Webjars jQuery UI package is defined as jquery-ui, not jqueryui.
